### PR TITLE
[Fix] (기타 수정사항) footer 버튼 상태관련 로직 변경

### DIFF
--- a/src/components/articleList/index.tsx
+++ b/src/components/articleList/index.tsx
@@ -1,11 +1,19 @@
+import { useDispatch } from "react-redux";
+import { useEffect } from "react";
+import { changeFooterBtnState } from "../../reducers/footerBtnState-Reducer";
+import { ArticleProps } from "../../models/articleProps";
+
 import { ListLayout } from "../../layout/layout";
 import Article from "../article";
 import useGetArticleData from "../../hooks/useGetArticleData";
 
-import { ArticleProps } from "../../models/articleProps";
-
 const ArticleList = () => {
+  const dispatch = useDispatch();
   const { articleInfo, articleInfoLoading, articleInfoError } = useGetArticleData();
+
+  useEffect(() => {
+    dispatch(changeFooterBtnState("home"));
+  }, []);
 
   if (articleInfoLoading || articleInfoError) {
     return <>indicator add</>;

--- a/src/components/footer/pageChangeBtn.tsx
+++ b/src/components/footer/pageChangeBtn.tsx
@@ -1,26 +1,16 @@
 import styled from "styled-components";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 import { GlobalStateProps } from "../../models/globalStateProps";
-import { changeFooterBtnState } from "../../reducers/footerBtnState-Reducer";
 
 const PageChangeBtn = (props: FooterProps) => {
   const iconImg = props.iconImg;
   const buttonText = props.buttonText;
   const type = props.type; // 'home' or 'scrap'
 
-  const dispatch = useDispatch();
   const footerBtnState = useSelector((state: GlobalStateProps) => state.footerBtnState);
 
-  const handleChangeFooterBtnState = () => {
-    if (type === "home") {
-      dispatch(changeFooterBtnState("home"));
-    } else if (type === "scrap") {
-      dispatch(changeFooterBtnState("scrap"));
-    }
-  };
-
   return (
-    <Container type={type} footerBtnState={footerBtnState} onClick={handleChangeFooterBtnState}>
+    <Container type={type} footerBtnState={footerBtnState}>
       <img src={iconImg} />
       <span>{buttonText}</span>
     </Container>

--- a/src/components/noScrapIndicator/index.tsx
+++ b/src/components/noScrapIndicator/index.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { changeFooterBtnState } from "../../reducers/footerBtnState-Reducer";
 import { Link } from "react-router-dom";
@@ -6,9 +7,10 @@ import { noScrapIndicatorIcon, noScrapMessage, goHomeButtonText } from "../../co
 
 const NoScrapIndicator = () => {
   const dispatch = useDispatch();
-  const handleChangeFooterBtnState = () => {
-    dispatch(changeFooterBtnState("home"));
-  };
+
+  useEffect(() => {
+    dispatch(changeFooterBtnState("scrap"));
+  }, []);
 
   return (
     <Container>
@@ -17,7 +19,7 @@ const NoScrapIndicator = () => {
         <span className="message">{noScrapMessage}</span>
       </div>
       <Link to="/">
-        <button onClick={handleChangeFooterBtnState} className="goHomeBtn">
+        <button className="goHomeBtn">
           <div className="buttonText">{goHomeButtonText}</div>
         </button>
       </Link>

--- a/src/components/scrapList/index.tsx
+++ b/src/components/scrapList/index.tsx
@@ -1,9 +1,18 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { changeFooterBtnState } from "../../reducers/footerBtnState-Reducer";
 import { ListLayout } from "../../layout/layout";
 // import Article from "../article";
 // import { dummyArticle } from "../../constants/constatns";
 // import { ArticleProps } from "../../models/articleProps";
 
 const ScrapList = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(changeFooterBtnState("scrap"));
+  }, []);
+
   return (
     <ListLayout>
       {/* {dummyArticle.map((article: ArticleProps) => {


### PR DESCRIPTION
- 기존 : footer 버튼 클릭 시 변경되도록 설정
- 변경 : articleList, scrapList 컴포넌트 마운트 시 useEffect에 의해 변경되도록 설정
- 변경 사유 : 뒤로 가기 버튼 등으로 페이지 이동 시 클릭 이벤트 반영이 안되어서 footer 버튼 상태가 변경되지 않는 문제 해결하기 위함